### PR TITLE
Fix Create and Delete for CampaignContribution/CampaignRating

### DIFF
--- a/src/DonateHope.Core/Services/CampaignContributionServices/CampaignContributionDeleteService.cs
+++ b/src/DonateHope.Core/Services/CampaignContributionServices/CampaignContributionDeleteService.cs
@@ -39,6 +39,12 @@ public class CampaignContributionDeleteService(
         
         var deletedCampaignContribution = queryResult.Value;
         
+        if (deletedCampaignContribution.IsDeleted)
+        {
+            _logger.LogWarning("The campaign contribution {CampaignContributionId} is already marked as deleted.", deletedCampaignContribution.Id);
+            return new ProblemDetailsError("This campaign contribution does not exist.");
+        }
+        
         if (deletedBy != deletedCampaignContribution.UserId)
         {
             _logger.LogWarning(
@@ -47,11 +53,6 @@ public class CampaignContributionDeleteService(
                 deletedCampaignContribution.Id
             );
             return new ProblemDetailsError("You are unauthorized to update this campaign contribution.");
-        }
-        if (deletedCampaignContribution.IsDeleted)
-        {
-            _logger.LogWarning("The campaign contribution {CampaignContributionId} is already marked as deleted.", deletedCampaignContribution.Id);
-            return new ProblemDetailsError("This campaign contribution does not exist.");
         }
         
         deletedCampaignContribution.DeletedAt = DateTime.UtcNow;

--- a/src/DonateHope.Core/Services/CampaignContributionServices/CampaignContributionDeleteService.cs
+++ b/src/DonateHope.Core/Services/CampaignContributionServices/CampaignContributionDeleteService.cs
@@ -38,6 +38,16 @@ public class CampaignContributionDeleteService(
         }
         
         var deletedCampaignContribution = queryResult.Value;
+        
+        if (deletedBy != deletedCampaignContribution.UserId)
+        {
+            _logger.LogWarning(
+                "User id {UserId} is unauthorized to update campaign contribution {CampaignContributionId}",
+                deletedBy,
+                deletedCampaignContribution.Id
+            );
+            return new ProblemDetailsError("You are unauthorized to update this campaign contribution.");
+        }
         if (deletedCampaignContribution.IsDeleted)
         {
             _logger.LogWarning("The campaign contribution {CampaignContributionId} is already marked as deleted.", deletedCampaignContribution.Id);

--- a/src/DonateHope.Core/Services/CampaignRatingServices/CampaignRatingDeleteService.cs
+++ b/src/DonateHope.Core/Services/CampaignRatingServices/CampaignRatingDeleteService.cs
@@ -36,6 +36,12 @@ public class CampaignRatingDeleteService(
         
         var deletedCampaignRating = queryResult.Value;
         
+        if (deletedCampaignRating.IsDeleted)
+        {
+            _logger.LogWarning("The campaign rating {CampaignRatingId} is already marked as deleted.", campaignRatingId);
+            return new ProblemDetailsError("This campaign rating does not exist.");
+        }
+        
         if (deletedBy != deletedCampaignRating.UserId)
         {
             _logger.LogWarning(
@@ -44,12 +50,6 @@ public class CampaignRatingDeleteService(
                 deletedCampaignRating.Id
             );
             return new ProblemDetailsError("You are unauthorized to update this campaign rating.");
-        }
-        
-        if (deletedCampaignRating.IsDeleted)
-        {
-            _logger.LogWarning("The campaign rating {CampaignRatingId} is already marked as deleted.", campaignRatingId);
-            return new ProblemDetailsError("This campaign rating does not exist.");
         }
         
         deletedCampaignRating.DeletedAt = DateTime.UtcNow;

--- a/src/DonateHope.Core/Services/CampaignRatingServices/CampaignRatingDeleteService.cs
+++ b/src/DonateHope.Core/Services/CampaignRatingServices/CampaignRatingDeleteService.cs
@@ -35,6 +35,17 @@ public class CampaignRatingDeleteService(
         }
         
         var deletedCampaignRating = queryResult.Value;
+        
+        if (deletedBy != deletedCampaignRating.UserId)
+        {
+            _logger.LogWarning(
+                "User id {UserId} is unauthorized to update campaign contribution {CampaignRatingId}",
+                deletedBy,
+                deletedCampaignRating.Id
+            );
+            return new ProblemDetailsError("You are unauthorized to update this campaign rating.");
+        }
+        
         if (deletedCampaignRating.IsDeleted)
         {
             _logger.LogWarning("The campaign rating {CampaignRatingId} is already marked as deleted.", campaignRatingId);

--- a/src/DonateHope.Core/Validators/CampaignContribution/CampaignContributionCreateRequestValidator.cs
+++ b/src/DonateHope.Core/Validators/CampaignContribution/CampaignContributionCreateRequestValidator.cs
@@ -1,0 +1,35 @@
+using DonateHope.Core.DTOs.CampaignContributionDTOs;
+using DonateHope.Domain.Enums;
+using FluentValidation;
+
+namespace DonateHope.Core.Validators.CampaignContribution;
+
+public class CampaignContributionCreateRequestValidator : AbstractValidator<CampaignContributionCreateRequestDto>
+{
+    public CampaignContributionCreateRequestValidator()
+    {
+        RuleFor(model => model.Amount)
+            .GreaterThanOrEqualTo(0)
+            .WithMessage("Amount must be greater than or equal to 0.");
+        
+        RuleFor(model => model.UnitOfMeasurement)
+            .Must(BeAValidUnitOfMeasurement)
+            .WithMessage("UnitOfMeasurement is not valid.");
+        
+        RuleFor(model => model.ContributionMethod)
+            .Must(BeAValidContributionMethod)
+            .WithMessage("ContributionMethod is not valid.");
+    }
+
+    private bool BeAValidUnitOfMeasurement(string? unitOfMeasurement)
+    {
+        return Enum.TryParse(typeof(MeasurementUnits), unitOfMeasurement, true, out var result) &&
+               Enum.IsDefined(typeof(MeasurementUnits), result);
+    }
+
+    public bool BeAValidContributionMethod(string? contributionMethod)
+    {
+        return Enum.TryParse(typeof(ContributionMethods), contributionMethod, true, out var result) &&
+               Enum.IsDefined(typeof(ContributionMethods), result);
+    }
+}

--- a/src/DonateHope.Core/Validators/CampaignRating/CampaignRatingCreateRequestValidator.cs
+++ b/src/DonateHope.Core/Validators/CampaignRating/CampaignRatingCreateRequestValidator.cs
@@ -1,0 +1,16 @@
+using DonateHope.Core.DTOs.CampaignRatingDTOs;
+using DonateHope.Domain.Enums;
+using FluentValidation;
+
+namespace DonateHope.Core.Validators.CampaignRating;
+
+public class CampaignRatingCreateRequestValidator : AbstractValidator<CampaignRatingCreateRequestDto>
+{
+    public CampaignRatingCreateRequestValidator()
+    {
+        RuleFor(model => model.RatingPoint)
+            .GreaterThanOrEqualTo(0)
+            .LessThanOrEqualTo(5)
+            .WithMessage("Rating point must be greater than or equal to 0 and less than or equal to 5.");
+    }
+}

--- a/src/DonateHope.Infrastructure/Repositories/CampaignContributionsRepository.cs
+++ b/src/DonateHope.Infrastructure/Repositories/CampaignContributionsRepository.cs
@@ -122,7 +122,7 @@ public class CampaignContributionsRepository(
     {
         using var dbConnection = await _dbConnectionFactory.CreateConnectionAsync();
         var queryResult = await _dbContext
-            .CampaignContributions.Where(cc => cc.Id == campaignContributionId)
+            .CampaignContributions.Where(cc => cc.Id == campaignContributionId && cc.IsDeleted == false)
             .FirstOrDefaultAsync();
         if (queryResult is null)
         {

--- a/src/DonateHope.Infrastructure/Repositories/CampaignRatingsRepository.cs
+++ b/src/DonateHope.Infrastructure/Repositories/CampaignRatingsRepository.cs
@@ -117,7 +117,7 @@ public class CampaignRatingsRepository(
     {
         using var dbConnection = await _dbConnectionFactory.CreateConnectionAsync();
         var queryResult = await _dbContext
-            .CampaignRatings.Where(cr => cr.Id == campaignRatingId)
+            .CampaignRatings.Where(cr => cr.Id == campaignRatingId && cr.IsDeleted == false)
             .FirstOrDefaultAsync();
         if (queryResult is null)
         {

--- a/src/DonateHope.Infrastructure/Repositories/CampaignReportsRepository.cs
+++ b/src/DonateHope.Infrastructure/Repositories/CampaignReportsRepository.cs
@@ -132,7 +132,7 @@ public class CampaignReportsRepository(
     {
         using var dbConnection = await _dbConnectionFactory.CreateConnectionAsync();
         var queryResult = await _dbContext
-            .CampaignReports.Where(cr => cr.Id == campaignReportId)
+            .CampaignReports.Where(cr => cr.Id == campaignReportId && cr.IsDeleted == false)
             .FirstOrDefaultAsync();
         if (queryResult is null)
         {

--- a/src/DonateHope.WebAPI/Controllers/v1/CampaignContribution/CampaignContributionController.cs
+++ b/src/DonateHope.WebAPI/Controllers/v1/CampaignContribution/CampaignContributionController.cs
@@ -20,8 +20,9 @@ public class CampaignContributionController(
     ICampaignContributionRetrieveService campaignContributionRetrieveService,
     ICampaignContributionUpdateService campaignContributionUpdateService,
     ICampaignContributionDeleteService campaignContributionDeleteService,
-    IValidator<CampaignContributionDeleteRequestDto> campaignContributionDeleteRequestValidator,
+    IValidator<CampaignContributionCreateRequestDto> campaignContributionCreateRequestValidator,
     IValidator<CampaignContributionUpdateRequestDto> campaignContributionUpdateRequestValidator,
+    IValidator<CampaignContributionDeleteRequestDto> campaignContributionDeleteRequestValidator,
     UserManager<AppUser> userManager,
     IOptions<MyAppServerConfiguration> myAppServerConfiguration,
     CampaignContributionMapper campaignContributionMapper
@@ -34,6 +35,7 @@ public class CampaignContributionController(
     private readonly ICampaignContributionRetrieveService _campaignContributionRetrieveService = campaignContributionRetrieveService;
     private readonly ICampaignContributionUpdateService _campaignContributionUpdateService = campaignContributionUpdateService;
     private readonly ICampaignContributionDeleteService _campaignContributionDeleteService = campaignContributionDeleteService;
+    private readonly IValidator<CampaignContributionCreateRequestDto> _campaignContributionCreateValidator = campaignContributionCreateRequestValidator;
     private readonly IValidator<CampaignContributionUpdateRequestDto> _campaignContributionUpdateValidator = campaignContributionUpdateRequestValidator;
     private readonly IValidator<CampaignContributionDeleteRequestDto> _campaignContributionDeleteValidator = campaignContributionDeleteRequestValidator;
 
@@ -50,6 +52,14 @@ public class CampaignContributionController(
         if (!Guid.TryParse(userId, out var parsedUserId))
         {
             return BadRequestProblemDetails("Unable to identify user");
+        }
+        
+        var modelValidationResult = await _campaignContributionCreateValidator.ValidateAsync(createRequest);
+        if (!modelValidationResult.IsValid)
+        {
+            return modelValidationResult.Errors.ToValidatingDetailedBadRequest(
+                title: "Failed to update campaign contribution.",
+                detail: "Make sure all the required fields are properly entered.");
         }
         
         var result = await _campaignContributionCreateService.CreateCampaignContributionAsync(
@@ -94,14 +104,6 @@ public class CampaignContributionController(
         [FromBody] CampaignContributionUpdateRequestDto updateRequestDto
     )
     {
-        var modelValidationResult = await _campaignContributionUpdateValidator.ValidateAsync(updateRequestDto);
-        if (!modelValidationResult.IsValid)
-        {
-            return modelValidationResult.Errors.ToValidatingDetailedBadRequest(
-                title: "Failed to update campaign contribution.",
-                detail: "Make sure all the required fields are properly entered.");
-        }
-        
         if (!Guid.TryParse(id, out var campaignContributionId))
         {
             return BadRequestProblemDetails("Invalid ID format");
@@ -122,6 +124,14 @@ public class CampaignContributionController(
         if (!Guid.TryParse(userId, out var parsedUserId))
         {
             return BadRequestProblemDetails("Unable to identify user.");
+        }
+        
+        var modelValidationResult = await _campaignContributionUpdateValidator.ValidateAsync(updateRequestDto);
+        if (!modelValidationResult.IsValid)
+        {
+            return modelValidationResult.Errors.ToValidatingDetailedBadRequest(
+                title: "Failed to update campaign contribution.",
+                detail: "Make sure all the required fields are properly entered.");
         }
 
         var updatedResult = await _campaignContributionUpdateService.UpdateCampaignContributionAsync(

--- a/src/DonateHope.WebAPI/StartupExtensions/DependencyInjectionServicesExtension.cs
+++ b/src/DonateHope.WebAPI/StartupExtensions/DependencyInjectionServicesExtension.cs
@@ -59,6 +59,7 @@ public static class DependencyInjectionServicesExtension
         services.TryAddScoped<ICampaignContributionRetrieveService, CampaignContributionRetrieveService>();
         services.TryAddScoped<ICampaignContributionUpdateService, CampaignContributionUpdateService>();
         services.TryAddScoped<ICampaignContributionDeleteService, CampaignContributionDeleteService>();
+        services.AddValidatorsFromAssemblyContaining<CampaignContributionCreateRequestValidator>();
         services.AddValidatorsFromAssemblyContaining<CampaignContributionUpdateRequestValidator>();
         services.AddValidatorsFromAssemblyContaining<CampaignContributionDeleteRequestValidator>();
         

--- a/src/DonateHope.WebAPI/StartupExtensions/DependencyInjectionServicesExtension.cs
+++ b/src/DonateHope.WebAPI/StartupExtensions/DependencyInjectionServicesExtension.cs
@@ -69,6 +69,7 @@ public static class DependencyInjectionServicesExtension
         services.TryAddScoped<ICampaignRatingRetrieveService, CampaignRatingRetrieveService>();
         services.TryAddScoped<ICampaignRatingUpdateService, CampaignRatingUpdateService>();
         services.TryAddScoped<ICampaignRatingDeleteService, CampaignRatingDeleteService>();
+        services.AddValidatorsFromAssemblyContaining<CampaignRatingCreateRequestValidator>();
         services.AddValidatorsFromAssemblyContaining<CampaignRatingUpdateRequestValidator>();
         
         services.TryAddScoped<ICampaignReportsRepository, CampaignReportsRepository>();


### PR DESCRIPTION
1. CampaignContribution
- Add CreateRequestValidator
- Add user check in delete service (if user is not the owner of the Campaign Contribution, then cannot delete)

2. CampaignRating
- Add CreateRequestValidator
- Add user check in delete service (if user is not the owner of the Campaign Raing, then cannot delete)